### PR TITLE
chore(cr): remove release branches from create-release action, so that default (master,main) is used

### DIFF
--- a/create-release/action.yaml
+++ b/create-release/action.yaml
@@ -55,7 +55,6 @@ runs:
       with:
         github_token: ${{ inputs.github_token }}
         default_bump: patch
-        release_branches: master
 
     - name: Fetch Refresh
       run: git fetch --prune --tags


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/711726/181278762-14e378e3-9daa-4f37-b314-228e7e75fa0b.png)
