### PR TITLE
fix: actually make go checks optional during a release

### DIFF
--- a/create-release/action.yaml
+++ b/create-release/action.yaml
@@ -34,7 +34,6 @@ inputs:
   check_command:
     description: The command to run to run checks and generate a code coverage report (Golang only).
     required: false
-    default: make check
   gradle_check_and_submit_command:
     description: The gradle tasks to run in addition to ./gradlew check build sonarqube (JVM only).
     required: false


### PR DESCRIPTION
I double checked that every Go project explicitly sets the check command.