### PR TITLE
chore(staticcheck): update staticcheck to 2023.1.5

### DIFF
--- a/golang-analyze-and-submit-to-sonar/action.yaml
+++ b/golang-analyze-and-submit-to-sonar/action.yaml
@@ -75,7 +75,7 @@ runs:
 
     - uses: dominikh/staticcheck-action@v1.3.0
       with:
-        version: "2022.1.1"
+        version: "2023.1.5"
         install-go: false
 
     - name: Upload Tests Reports to Github


### PR DESCRIPTION
this is a minor version bump (0.3.3 -> 0.4.5) that adds support to go 1.19 & 1.20 

No new checks are added but several are improved, see details: https://github.com/dominikh/go-tools/releases/tag/2023.1