### PR TITLE
fix: turn off caching

### DIFF
--- a/golang-analyze-and-submit-to-sonar/action.yaml
+++ b/golang-analyze-and-submit-to-sonar/action.yaml
@@ -51,15 +51,6 @@ runs:
       with:
         go-version: ${{ inputs.go_version }}
         go-version-file: go.mod
-        
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Run Check 
       env:


### PR DESCRIPTION
the setup-go action already caches our go dependencies, and we're hitting this issue about 50,000 times in our CI logs: https://github.com/actions/cache/issues/1104